### PR TITLE
ci: add workflow_dispatch to CI - Health Service

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, modularization/rfc]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   test-health:


### PR DESCRIPTION
Add manual dispatch trigger to the health CI workflow so it can be run via .