### PR TITLE
ci: make health CI resilient and fix docker-publish expressions

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -19,8 +19,15 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r services/health/requirements.txt
-          pip install pytest
+          echo "Listing workspace files for debugging..."
+          ls -R . | sed -n '1,200p'
+          if [ -f services/health/requirements.txt ]; then
+            echo "Found services/health/requirements.txt — installing from file"
+            pip install -r services/health/requirements.txt
+          else
+            echo "services/health/requirements.txt not found — falling back to explicit installs"
+            pip install fastapi==0.95.2 uvicorn[standard]==0.22.0 pytest
+          fi
       - name: Run tests
         run: |
           pytest services/health/tests -q

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,63 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches: [ main ]
+    tags:    ['v*', 'release-*']
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Determine image name and tag
+        id: meta
+        run: |
+          # Use the secret via GitHub expression, fallbacks handled in shell
+          IMAGE_USER="${{ secrets.DOCKERHUB_USERNAME }}"
+          # Allow optional repo/version to be provided via environment variables; otherwise use sensible defaults
+          IMAGE_REPO="${DOCKERHUB_REPO:-autorisen}"
+          GIT_SHA=$(git rev-parse --short HEAD)
+          DATE_UTC=$(date -u +%Y%m%d-%H%M)
+          VERSION="${DOCKERHUB_VERSION:-${DATE_UTC}-${GIT_SHA}}"
+          echo "IMAGE=${IMAGE_USER}/${IMAGE_REPO}" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image (backend)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: backend/Dockerfile
+          platforms: linux/amd64
+          target: backend
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.IMAGE }}:${{ steps.meta.outputs.VERSION }}
+            ${{ steps.meta.outputs.IMAGE }}:latest
+
+      - name: Image published
+        run: |
+          echo "Published ${{ steps.meta.outputs.IMAGE }}:${{ steps.meta.outputs.VERSION }} and :latest"
+
+# Notes:
+# - Create repository secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
+# - Optional repo-level envs (in Actions UI) you can set: DOCKERHUB_REPO, DOCKERHUB_VERSION
+# - This workflow builds the backend target from `backend/Dockerfile` and pushes two tags.


### PR DESCRIPTION
Adds resilient install fallback for ci-health and fixes invalid expressions in docker-publish.yml.

- ci-health: if  is missing, fall back to explicit pip installs and list workspace files for debugging.
- docker-publish: use shell fallbacks for DOCKERHUB_REPO/DOCKERHUB_VERSION.
