### PR TITLE
ci(health): skip tests when PoC absent

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -30,4 +30,9 @@ jobs:
           fi
       - name: Run tests
         run: |
-          pytest services/health/tests -q
+          if [ -d services/health/tests ]; then
+            pytest services/health/tests -q
+          else
+            echo "No health tests found (services/health/tests). Skipping tests." 
+            exit 0
+          fi


### PR DESCRIPTION
Avoid failing CI for branches that don't include the PoC health service by skipping the test step when  is missing.