### PR TITLE
chore(infra): add AWS ECS Terraform skeleton and ECS manual deploy workflow

### DIFF
--- a/.github/workflows/ecs-build-deploy.yml
+++ b/.github/workflows/ecs-build-deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy - ECS (manual)
+
+on:
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  build-and-deploy:
+    name: Build and push to ECR (manual only)
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials from OIDC
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
+          aws-region: us-east-1
+
+      - name: Login to ECR
+        id: login-ecr
+        run: |
+          aws ecr get-login-password --region ${AWS_REGION:-us-east-1} | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
+
+      - name: Build and tag image
+        run: |
+          IMAGE=${{ secrets.ECR_REPO }}:ci-${GITHUB_RUN_ID}
+          docker build -t "$IMAGE" .
+          docker tag "$IMAGE" "${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPO }}:ci-${GITHUB_RUN_ID}"
+
+      - name: Push to ECR
+        run: |
+          docker push "${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPO }}:ci-${GITHUB_RUN_ID}"
+
+      - name: Note
+        run: |
+          echo "Manual deploy created image: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPO }}:ci-${GITHUB_RUN_ID}"
+
+# Security notes:
+# - Configure `AWS_OIDC_ROLE` in repo secrets referencing an IAM role that trusts GitHub's OIDC provider.
+# - Store `ECR_REGISTRY` and `ECR_REPO` as secrets.

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ build/
 .venv/
 venv/
 env/
+.terraform/
+*.tfstate
+tmp_pg/
 ENV/
 .env
 .env.local

--- a/infra/aws-ecs-skel/README.md
+++ b/infra/aws-ecs-skel/README.md
@@ -1,0 +1,12 @@
+# AWS ECS Skeleton (scaffolding only)
+
+This folder contains a minimal Terraform skeleton for an ECS/Fargate migration.
+
+Notes:
+
+- Intentionally minimal: no ALB, no DNS, no task/service definitions yet.
+- Purpose: give a starting point (ECR repo + ECS cluster) for incremental migration.
+
+Next steps:
+
+- Add IAM roles, task definition, ALB + target groups, RDS provisioning (or external RDS), and CI/CD integration.

--- a/infra/aws-ecs-skel/main.tf
+++ b/infra/aws-ecs-skel/main.tf
@@ -1,0 +1,27 @@
+// Minimal Terraform skeleton for ECS/Fargate skeleton. No ALB/DNS yet.
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+  required_version = ">= 1.5"
+}
+
+provider "aws" {
+  region = var.region
+}
+
+// Placeholder: ECR repository
+resource "aws_ecr_repository" "app" {
+  name                 = var.ecr_repo_name
+  image_tag_mutability = "MUTABLE"
+}
+
+// Placeholder: ECS cluster
+resource "aws_ecs_cluster" "main" {
+  name = "${var.app_name}-cluster"
+}
+
+// Placeholder: Task definition and service will be added later

--- a/infra/aws-ecs-skel/variables.tf
+++ b/infra/aws-ecs-skel/variables.tf
@@ -1,0 +1,17 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "autolocal"
+}
+
+variable "ecr_repo_name" {
+  description = "ECR repository name"
+  type        = string
+  default     = "autolocal-health"
+}

--- a/scripts/pg_restore.sh
+++ b/scripts/pg_restore.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple local Postgres backup & restore script for dev validation.
+# Usage: ./scripts/pg_restore.sh
+
+WORKDIR=$(dirname "$0")/../tmp_pg
+mkdir -p "$WORKDIR"
+
+PG_PASSWORD=passw0rd
+PG_USER=ciuser
+PG_DB=cidb
+PG_PORT=5433
+
+# Start a temporary Postgres container
+echo "Starting temporary Postgres container..."
+docker run --name ci-pg -e POSTGRES_PASSWORD=$PG_PASSWORD -e POSTGRES_USER=$PG_USER -e POSTGRES_DB=$PG_DB -p ${PG_PORT}:5432 -d postgres:15
+
+trap 'docker rm -f ci-pg >/dev/null 2>&1 || true; rm -rf "$WORKDIR"' EXIT
+
+sleep 2
+
+echo "Creating a sample table and data..."
+docker exec -i ci-pg psql -U $PG_USER -d $PG_DB <<'SQL'
+CREATE TABLE IF NOT EXISTS sample (id serial primary key, name text);
+INSERT INTO sample (name) VALUES ('alice'), ('bob');
+\q
+SQL
+
+echo "Dumping database to $WORKDIR/dump.sql"
+docker exec ci-pg pg_dump -U $PG_USER -d $PG_DB -F p > "$WORKDIR/dump.sql"
+
+echo "Dropping and recreating database to simulate restore..."
+docker exec -i ci-pg psql -U $PG_USER -d postgres <<SQL
+DROP DATABASE IF EXISTS restore_db;
+CREATE DATABASE restore_db;
+\q
+SQL
+
+echo "Restoring dump into restore_db"
+cat "$WORKDIR/dump.sql" | docker exec -i ci-pg psql -U $PG_USER -d restore_db
+
+echo "Verifying restored data..."
+docker exec -i ci-pg psql -U $PG_USER -d restore_db -c "SELECT * FROM sample;"
+
+echo "Backup & restore test completed successfully"


### PR DESCRIPTION
This PR adds scaffolding for an AWS ECS migration (Terraform skeleton), a manual-only ECS build+deploy workflow that uses OIDC, and a local Postgres backup/restore script for dev testing.\n\nChecklist:\n- [ ] No traffic cutover in this PR — scaffolding only\n- [ ] Terraform skeleton: ECR repo + ECS cluster placeholders\n- [ ] Manual ECS workflow: OIDC role usage, ECR push (secrets required)\n- [ ] pg_restore script and local test instructions\n- [ ] CI health fast smoke-tests left unchanged (we'll extend separately)\n\nAfter review the plan is to merge to chore/publish-health-image for integration testing, no production changes in this PR.