### PR TITLE
chore(ci): add live-audit workflow (manual)

### DIFF
--- a/.github/workflows/live-audit.yml
+++ b/.github/workflows/live-audit.yml
@@ -1,0 +1,40 @@
+name: Live Audit - Heroku & AWS (manual)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  run-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials from OIDC
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
+          aws-region: us-east-1
+
+      - name: Install tools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y jq curl
+          python3 -m pip install --user heroku3 || true
+
+      - name: Run live audit
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          chmod +x .github/scripts/live_audit.sh
+          .github/scripts/live_audit.sh
+
+      - name: Upload audit artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-audit-output
+          path: audit-output


### PR DESCRIPTION
Adds a manual live audit workflow to run a read-only audit against AWS and optional Heroku. This is a small, manual-only workflow (workflow_dispatch) that uploads an artifact named 'live-audit-output'.